### PR TITLE
Feature/hu26 surtir inventario

### DIFF
--- a/frontend/src/features/inventario/InventoryAdminPage.jsx
+++ b/frontend/src/features/inventario/InventoryAdminPage.jsx
@@ -47,6 +47,8 @@ const InventoryAdminPage = () => {
     const [productos, setProductos] = useState([]);
     const [categorias, setCategorias] = useState([]);
     const [vistaProductos, setVistaProductos] = useState(VISTA_TODOS);
+    const [modo, setModo] = useState("productos"); // "productos" | "surtir"
+    const [cantidadesSurtir, setCantidadesSurtir] = useState({});
 
     const [showModal, setShowModal] = useState(false);
     const [showOfferModal, setShowOfferModal] = useState(false);
@@ -274,6 +276,26 @@ const InventoryAdminPage = () => {
         }
     };
 
+    const handleSurtir = async () => {
+        const items = Object.entries(cantidadesSurtir)
+            .filter(([, v]) => Number(v) > 0)
+            .map(([producto_id, cantidad_adicional]) => ({
+                producto_id: Number(producto_id),
+                cantidad_adicional: Number(cantidad_adicional),
+            }));
+        if (items.length === 0) {
+            alert("Ingresa al menos una cantidad mayor a 0.");
+            return;
+        }
+        try {
+            await axios.post(`${API_BASE_URL}/api/v1/inventario/surtir/`, { items });
+            await fetchData();
+            setCantidadesSurtir({});
+        } catch (_err) {
+            alert(_err.response?.data?.detail || JSON.stringify(_err.response?.data || "Error al surtir."));
+        }
+    };
+
     const descuentoOferta = parseInt(offerDraft.descuento_porcentaje, 10);
     const descuentoValido =
         !offerDraft.en_oferta || (!Number.isNaN(descuentoOferta) && descuentoOferta >= 1 && descuentoOferta <= 100);
@@ -402,6 +424,41 @@ const InventoryAdminPage = () => {
                     </div>
                 </div>
 
+                <div style={{ display: 'flex', gap: '12px', marginBottom: '24px' }}>
+                    <button
+                        type="button"
+                        onClick={() => setModo("productos")}
+                        style={{
+                            padding: '10px 18px',
+                            borderRadius: '999px',
+                            border: '1px solid rgba(255,255,255,0.08)',
+                            background: modo === "productos" ? 'var(--primary-green)' : 'var(--surface-low)',
+                            color: modo === "productos" ? '#000' : 'var(--text-primary)',
+                            fontWeight: 700,
+                            cursor: 'pointer',
+                        }}
+                    >
+                        Gestionar productos
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setModo("surtir")}
+                        style={{
+                            padding: '10px 18px',
+                            borderRadius: '999px',
+                            border: '1px solid rgba(255,255,255,0.08)',
+                            background: modo === "surtir" ? 'var(--primary-green)' : 'var(--surface-low)',
+                            color: modo === "surtir" ? '#000' : 'var(--text-primary)',
+                            fontWeight: 700,
+                            cursor: 'pointer',
+                        }}
+                    >
+                        Surtir stock
+                    </button>
+                </div>
+
+                {modo === "productos" && (
+                <>
                 <div
                     className="hide-scrollbar"
                     style={{
@@ -705,6 +762,89 @@ const InventoryAdminPage = () => {
                         </div>
                     )}
                 </div>
+                </>
+                )}
+
+                {modo === "surtir" && (
+                <div className="glass-card" style={{ padding: 'var(--spacing-xl)' }}>
+                    <h2 style={{ marginBottom: '24px' }}>Surtir productos</h2>
+                    <table
+                        data-testid="tabla-surtir"
+                        style={{ borderCollapse: 'collapse', width: '100%', textAlign: 'left' }}
+                    >
+                        <thead>
+                            <tr
+                                style={{
+                                    borderBottom: '1px solid rgba(255,255,255,0.05)',
+                                    background: 'rgba(255,255,255,0.02)',
+                                }}
+                            >
+                                <th
+                                    style={{ padding: '16px 20px', color: 'var(--text-secondary)' }}
+                                    className="label-caps"
+                                >
+                                    Producto
+                                </th>
+                                <th
+                                    style={{ padding: '16px 20px', color: 'var(--text-secondary)' }}
+                                    className="label-caps"
+                                >
+                                    Stock actual
+                                </th>
+                                <th
+                                    style={{ padding: '16px 20px', color: 'var(--text-secondary)' }}
+                                    className="label-caps"
+                                >
+                                    Cantidad a agregar
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {productos.map((producto) => (
+                                <tr
+                                    key={producto.id}
+                                    style={{ borderBottom: '1px solid rgba(255,255,255,0.03)' }}
+                                >
+                                    <td style={{ padding: '12px 20px', fontWeight: 600 }}>
+                                        {producto.nombre}
+                                    </td>
+                                    <td style={{ padding: '12px 20px' }}>
+                                        {producto.existencias} und
+                                    </td>
+                                    <td style={{ padding: '12px 20px' }}>
+                                        <input
+                                            type="number"
+                                            min="1"
+                                            placeholder="0"
+                                            value={cantidadesSurtir[producto.id] || ""}
+                                            onChange={(e) =>
+                                                setCantidadesSurtir((prev) => ({
+                                                    ...prev,
+                                                    [producto.id]: e.target.value,
+                                                }))
+                                            }
+                                            data-testid={`input-surtir-${producto.id}`}
+                                            className="premium-input"
+                                            style={{ width: '100px', padding: '8px' }}
+                                        />
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                    <div style={{ marginTop: '24px' }}>
+                        <button
+                            type="button"
+                            className="btn-primary"
+                            style={{ width: 'auto', padding: '12px 28px' }}
+                            onClick={handleSurtir}
+                            data-testid="btn-aplicar-surtido"
+                        >
+                            Aplicar surtido
+                        </button>
+                    </div>
+                </div>
+                )}
             </div>
 
             <AnimatePresence>

--- a/frontend/src/features/inventario/InventoryAdminPage.test.jsx
+++ b/frontend/src/features/inventario/InventoryAdminPage.test.jsx
@@ -146,3 +146,58 @@ describe('InventoryAdminPage ofertas', () => {
     });
   });
 });
+
+describe('InventoryAdminPage surtir inventario', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.alert = vi.fn();
+    window.confirm = vi.fn(() => true);
+    window.prompt = vi.fn();
+
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/inventario/categorias/')) {
+        return Promise.resolve({ data: categorias });
+      }
+      return Promise.resolve({ data: productosBase });
+    });
+
+    axios.post.mockResolvedValue({ data: { actualizados: [] } });
+  });
+
+  it('CP-HU26-04: muestra tabla de surtido con stock actual de cada producto', async () => {
+    renderInventoryPage();
+
+    await screen.findByText('Ron Dorado');
+
+    fireEvent.click(screen.getByText('Surtir stock'));
+
+    expect(await screen.findByTestId('tabla-surtir')).toBeInTheDocument();
+    expect(screen.getByText('Ron Dorado')).toBeInTheDocument();
+    expect(screen.getByText('Whisky Reserva')).toBeInTheDocument();
+    expect(screen.getByTestId(`input-surtir-${productosBase[0].id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`input-surtir-${productosBase[1].id}`)).toBeInTheDocument();
+  });
+
+  it('CP-HU26-05: aplica surtido solo con productos que tienen cantidad mayor a cero', async () => {
+    renderInventoryPage();
+
+    await screen.findByText('Ron Dorado');
+
+    fireEvent.click(screen.getByText('Surtir stock'));
+
+    await screen.findByTestId('tabla-surtir');
+
+    fireEvent.change(screen.getByTestId(`input-surtir-${productosBase[0].id}`), {
+      target: { value: '5' },
+    });
+
+    fireEvent.click(screen.getByTestId('btn-aplicar-surtido'));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://127.0.0.1:8000/api/v1/inventario/surtir/',
+        { items: [{ producto_id: productosBase[0].id, cantidad_adicional: 5 }] }
+      );
+    });
+  });
+});

--- a/inventario/infraestructura/serializers.py
+++ b/inventario/infraestructura/serializers.py
@@ -145,3 +145,22 @@ class CategoriaInventarioSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(f"La categoría '{value}' ya existe.")
 
         return value
+
+
+class SurtirItemSerializer(serializers.Serializer):
+    producto_id = serializers.IntegerField()
+    cantidad_adicional = serializers.IntegerField(min_value=1)
+
+    def validate_producto_id(self, value):
+        if not ProductoModelo.objects.filter(pk=value).exists():
+            raise serializers.ValidationError(f"No existe un producto con id {value}.")
+        return value
+
+
+class SurtirBulkSerializer(serializers.Serializer):
+    items = SurtirItemSerializer(many=True)
+
+    def validate_items(self, value):
+        if not value:
+            raise serializers.ValidationError("Debes enviar al menos un producto.")
+        return value

--- a/inventario/infraestructura/views.py
+++ b/inventario/infraestructura/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -137,3 +138,42 @@ class InventarioCategoriaDetailView(APIView):
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+
+class SurtirInventarioView(APIView):
+    """
+    HU-26: Surtir inventario en bulk.
+    POST /api/v1/inventario/surtir/
+    Body: {"items": [{"producto_id": 1, "cantidad_adicional": 10}, ...]}
+    """
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        from .serializers import SurtirBulkSerializer
+
+        serializer = SurtirBulkSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        items = serializer.validated_data["items"]
+        resultados = []
+
+        with transaction.atomic():
+            ids = [item["producto_id"] for item in items]
+            productos = {
+                p.pk: p
+                for p in ProductoModelo.objects.select_for_update().filter(pk__in=ids)
+            }
+            for item in items:
+                producto = productos[item["producto_id"]]
+                producto.existencias += item["cantidad_adicional"]
+                if producto.existencias > 0:
+                    producto.esta_activo = True
+                producto.save(update_fields=["existencias", "esta_activo"])
+                resultados.append({
+                    "producto_id": producto.pk,
+                    "nombre": producto.nombre,
+                    "existencias_nuevas": producto.existencias,
+                })
+
+        return Response({"actualizados": resultados}, status=status.HTTP_200_OK)

--- a/inventario/tests.py
+++ b/inventario/tests.py
@@ -170,3 +170,62 @@ class InventarioEliminarCategoriaTests(TestCase):
         response = self.client.delete("/api/v1/inventario/categorias/99999/")
 
         self.assertEqual(response.status_code, 404)
+
+
+class SurtirInventarioTests(TestCase):
+    """CP-HU26-01, CP-HU26-02, CP-HU26-03"""
+
+    def setUp(self):
+        self.categoria = CategoriaModelo.objects.create(nombre="Rones")
+        self.producto1 = ProductoModelo.objects.create(
+            nombre="Ron Medellín",
+            precio=50000,
+            categoria=self.categoria,
+            existencias=10,
+            esta_activo=True,
+        )
+        self.producto2 = ProductoModelo.objects.create(
+            nombre="Ron Viejo de Caldas",
+            precio=35000,
+            categoria=self.categoria,
+            existencias=5,
+            esta_activo=True,
+        )
+        self.url = "/api/v1/inventario/surtir/"
+
+    def test_surtido_valido_incrementa_existencias(self):
+        """CP-HU26-01: surtido válido de múltiples productos retorna 200 y stocks actualizados"""
+        payload = {
+            "items": [
+                {"producto_id": self.producto1.pk, "cantidad_adicional": 20},
+                {"producto_id": self.producto2.pk, "cantidad_adicional": 15},
+            ]
+        }
+        response = self.client.post(
+            self.url, data=payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.producto1.refresh_from_db()
+        self.producto2.refresh_from_db()
+        self.assertEqual(self.producto1.existencias, 30)
+        self.assertEqual(self.producto2.existencias, 20)
+
+    def test_cantidad_cero_retorna_400(self):
+        """CP-HU26-02: cantidad_adicional = 0 es rechazado con HTTP 400"""
+        payload = {
+            "items": [{"producto_id": self.producto1.pk, "cantidad_adicional": 0}]
+        }
+        response = self.client.post(
+            self.url, data=payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_producto_inexistente_retorna_400(self):
+        """CP-HU26-03: producto_id que no existe retorna HTTP 400"""
+        payload = {
+            "items": [{"producto_id": 99999, "cantidad_adicional": 10}]
+        }
+        response = self.client.post(
+            self.url, data=payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)

--- a/inventario/urls.py
+++ b/inventario/urls.py
@@ -5,6 +5,7 @@ from .infraestructura.views import (
     InventarioCategoriaListCreateView,
     InventarioProductoDetailView,
     InventarioProductoListCreateView,
+    SurtirInventarioView,
 )
 
 urlpatterns = [
@@ -20,4 +21,5 @@ urlpatterns = [
         InventarioCategoriaDetailView.as_view(),
         name="inventario_categoria_detalle",
     ),
+    path("surtir/", SurtirInventarioView.as_view(), name="inventario_surtir"),
 ]


### PR DESCRIPTION
## HU-26 — Surtir Inventario

### ¿Qué hace este PR?
Agrega la funcionalidad de surtido masivo de inventario en una sola operación.

### Backend
- Endpoint `POST /api/v1/inventario/surtir/` con transacción atómica (`select_for_update`)
- Validación: `cantidad_adicional > 0`, `producto_id` debe existir
- 3 nuevos tests Django (CP-HU26-01, CP-HU26-02, CP-HU26-03) — 13/13 pasando

### Frontend
- Tab "Surtir stock" en `/admin/inventario`
- Tabla editable con stock actual y campo cantidad por producto
- Filtra ítems vacíos antes de enviar
- 2 nuevos tests Vitest (CP-HU26-04, CP-HU26-05) — pasando

### Checklist
- [x] `ruff check .` — 0 errores
- [x] `npm run lint` — 0 errores
- [x] 13 tests backend pasando
- [x] CP manuales ejecutados y aprobados
- [x] Issues #43, #44, #45 cerrados